### PR TITLE
Minor fix: markdown styling of the HTTP Status Codes table

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -48,9 +48,12 @@ use of HTTP status codes.
 
 | `200 OK`
 | Standard response for successful HTTP requests.
-| The actual response will depend on the request method used.
-| In a GET request, the response will contain an entity corresponding to the requested resource.
-| In a POST request, the response will contain an entity describing or containing the result of the action.
+
+The actual response will depend on the request method used.
+
+In a GET request, the response will contain an entity corresponding to the requested resource.
+
+In a POST request, the response will contain an entity describing or containing the result of the action.
 
 | `201 Created`
 | The request has been fulfilled and resulted in a new resource being created.
@@ -136,4 +139,3 @@ include::{snippets}/update-person/curl-request.adoc[]
 ==== Example response
 
 include::{snippets}/update-person/http-response.adoc[]
-


### PR DESCRIPTION
There was a minor bug in the markdown styling of the HTTP Status Codes table, fixed it with this PR.

**Currently**:
<img width="659" alt="md-before" src="https://cloud.githubusercontent.com/assets/950503/14345676/9765fbf6-fcae-11e5-8f3d-b475a4b5608b.png">

**With this PR**:
<img width="665" alt="md-after" src="https://cloud.githubusercontent.com/assets/950503/14345679/9b6001e8-fcae-11e5-809e-a1259f299591.png">
